### PR TITLE
fix(packages/viewer): adjust loading spinner styles

### DIFF
--- a/apps/official-website/src/pages/editor/editor.tsx
+++ b/apps/official-website/src/pages/editor/editor.tsx
@@ -118,7 +118,6 @@ const Editor = () => {
           cameraOptions={{
             initialCameraPosition: new Vector3(0, 5, 5),
           }}
-          loader={<LoadingSpinner />}
         />
       ) : (
         <DropZone key="drop-zone" />

--- a/packages/viewer/src/components/default-spinner.tsx
+++ b/packages/viewer/src/components/default-spinner.tsx
@@ -2,7 +2,7 @@ import { Oval } from 'react-loader-spinner';
 
 const DefaultSpinner = () => {
   return (
-    <Oval height="100px" width="100px" color="#fff" secondaryColor="#fff" />
+    <Oval width="3rem" color="white" secondaryColor="white" strokeWidth="3" />
   );
 };
 

--- a/packages/viewer/src/components/spinner-wrapper.tsx
+++ b/packages/viewer/src/components/spinner-wrapper.tsx
@@ -4,7 +4,7 @@ interface Props {
 
 const SpinnerWrapper = ({ loader }: Props) => {
   return (
-    <div className="flex items-center justify-center absolute w-full h-full">
+    <div className="flex items-center justify-center w-full h-full">
       {loader}
     </div>
   );


### PR DESCRIPTION
This pull request includes several changes aimed at improving the loading spinner components and their usage across different parts of the application. The most important changes include modifying the spinner component's properties, removing unnecessary elements, and updating the layout.

Updates to spinner components:

* [`packages/viewer/src/components/default-spinner.tsx`](diffhunk://#diff-2a23981e042a09fcf9568faa1a05121ec50556f8c5fd05fb0c9c8a97cba9b33bL5-R5): Changed the `Oval` spinner's dimensions and stroke width for better visual consistency.
* [`packages/viewer/src/components/spinner-wrapper.tsx`](diffhunk://#diff-2d54e8aff3b6f18e2960d6b038493a92dc287a09b0bf58bffd6d68e6d6213d43L7-R7): Removed the `absolute` class from the wrapper div to fix the layout.

Usage updates:

* [`apps/official-website/src/pages/editor/editor.tsx`](diffhunk://#diff-0a65a8e2e1a2beae2395a53f47e4d7669c6716d48ef93a6d59825008104dd2fcL121): Removed the `loader` prop from the `Editor` component to streamline the code.