### PR TITLE
ci(workflows): add Chromatic workflow for Storybook publishing and up…

### DIFF
--- a/.github/workflows/chromatic-vctrl-viewer.yaml
+++ b/.github/workflows/chromatic-vctrl-viewer.yaml
@@ -1,0 +1,30 @@
+name: Publish vctrl/viewer Storybook to Chromatic
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  chromatic:
+    name: Run Chromatic
+    runs-on: ubuntu-22.04
+    environment: chromatic-publishing
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run Chromatic
+        uses: chromaui/action@latest
+        with:
+          projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN_1 }}
+          workingDir: packages/viewer

--- a/.github/workflows/lint-build.yaml
+++ b/.github/workflows/lint-build.yaml
@@ -22,7 +22,7 @@ jobs:
           cache: 'npm'
 
       - name: Install dependencies
-        run: npm install
+        run: npm ci
 
       - name: Lint
         run: npx nx affected --target=lint --base=origin/${{ github.event.pull_request.base.ref }} --head=origin/${{ github.event.pull_request.head.ref }}

--- a/.github/workflows/version-release.yaml
+++ b/.github/workflows/version-release.yaml
@@ -28,7 +28,7 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
 
       - name: Install dependencies
-        run: npm install
+        run: npm ci
 
       - name: Setup Git
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ vite.config.ts.timestamp-*
 .DS_Store
 **/vite.config.{js,ts,mjs,mts,cjs,cts}.timestamp*
 storybook-static
+*.log

--- a/packages/viewer/package.json
+++ b/packages/viewer/package.json
@@ -23,7 +23,7 @@
     "model-viewer"
   ],
   "repository": {
-    "url": "https://github.com/vectreal/vectreal-core",
+    "url": "git+https://github.com/vectreal/vectreal-core.git",
     "type": "https"
   },
   "license": "AGPL-3.0-only",
@@ -41,6 +41,10 @@
       "types": "./index.d.ts"
     },
     "./css": "./style.css"
+  },
+  "scripts": {
+    "build-storybook": "storybook build",
+    "chromatic": "npx chromatic --project-token=chpt_b3f4d26ac3d3190"
   },
   "peerDependencies": {
     "react": "^18.0.0"

--- a/packages/viewer/project.json
+++ b/packages/viewer/project.json
@@ -38,6 +38,12 @@
         "outputPath": "dist/packages/vctrl/viewer",
         "configFile": "packages/viewer/vite.config.ts"
       }
+    },
+    "chromatic": {
+      "executor": "nx:run-commands",
+      "options": {
+        "commands": ["npm --prefix packages/viewer run chromatic"]
+      }
     }
   }
 }


### PR DESCRIPTION
This pull request includes changes to the GitHub Actions workflows to improve dependency installation and add a new workflow for publishing Storybook to Chromatic. The most important changes are listed below:

### New Workflow Addition:

* Added a new workflow `.github/workflows/chromatic-vctrl-viewer.yaml` to publish the `vctrl/viewer` Storybook to Chromatic. This workflow is triggered on pushes to the `main` branch and includes steps for checking out the code, setting up Node.js, installing dependencies, and running Chromatic.

### Workflow Improvements:

* Updated the dependency installation step in `.github/workflows/lint-build.yaml` to use `npm ci` instead of `npm install` for faster and more reliable builds.
* Updated the dependency installation step in `.github/workflows/version-release.yaml` to use `npm ci` instead of `npm install` for consistency and improved performance.